### PR TITLE
Add layouts to PurgeCSS content

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,16 +13,21 @@ module.exports = {
 	important: true, // See https://tailwindcss.com/docs/configuration#important
 	purge: {
 		enabled: process.env.HUGO_ENVIRONMENT === 'production',
-		content: [ './hugo_stats.json' ],
+    content: [
+      './hugo_stats.json',
+      './layouts/**/*.html',
+		],
+		extractors: [
+      {
+        extractor: (content) => {
+					let els = JSON.parse(content).htmlElements;
+					return els.tags.concat(els.classes, els.ids);
+				},
+        extensions: ['json']
+      },
+    ],
 		mode: 'all',
-		options: {
-			//whitelist: [ 'pl-1', 'pl-3' ],
-			defaultExtractor: (content) => {
-				let els = JSON.parse(content).htmlElements;
-				els = els.tags.concat(els.classes, els.ids);
-				return els;
-			}
-		}
+		
 	},
 	plugins: [ typography ]
 };


### PR DESCRIPTION
The purpose of this PR is to also include the basic "template crawling" in PurgeCSS on top of `hugo_stats.json`.

In order to gain on build time on CI, (netlify etc...) `useResourceCacheWhen: always` is set. 
CI will trigger a build when content is changed by editor and use cached resources. But classes might be added by editors actions (addition of a rarely used banner, change in layout type etc...). Unique TW CSS classes printed by those changes won't be included in cached CSS file used on latest build.

User can comment out './layouts/**/*.html' if not needed.