### PR TITLE
Fix postcss config: console.log output should be put in comment

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,7 +2,7 @@ let tailwindConfig = process.env.HUGO_FILE_TAILWIND_CONFIG_JS || './tailwind.con
 const tailwind = require('tailwindcss')(tailwindConfig);
 const autoprefixer = require('autoprefixer');
 
-console.log('Using postcss.config.js from ' + tailwindConfig);
+console.log(`/* Using postcss.config.js from ${tailwindConfig} */`);
 
 module.exports = {
 	// eslint-disable-next-line no-process-env


### PR DESCRIPTION
<img width="864" alt="image" src="https://github.com/bep/hugo-starter-tailwind-basic/assets/5097752/639eb922-d0a7-4b89-ab3f-2ad83522a64b">

the `console.log` output has been written to the output CSS file, and it should be put into a comment block otherwise it would invalidate the first CSS rule.
 