### PR TITLE
Update package.hugo.json

### DIFF
--- a/package.hugo.json
+++ b/package.hugo.json
@@ -6,12 +6,11 @@
 	},
 	"dependencies": {},
 	"devDependencies": {
-		"@tailwindcss/typography": "^0.4.1",
-		"autoprefixer": "^10.3.1",
-		"postcss": "^8.3.6",
-		"postcss-cli": "^8.3.1",
-		"postcss-purgecss": "^2.0.3",
-		"tailwindcss": "^2.2.7"
+		"@tailwindcss/typography": "^0.5.9",
+		"autoprefixer": "^10.4.14",
+		"postcss": "^8.4.23",
+		"postcss-cli": "^10.1.0",
+		"tailwindcss": "^3.3.2"
 	},
 	"name": "hugo-starter-tailwind-basic",
 	"version": "0.1.0"


### PR DESCRIPTION
To match recent changes to package.json (7c68e60e045ee675f373e8d5cc51a9ae5ed0f5b7 and a332c9c905202adbed54585ffecb6606dca5ea4f). Prior to those changes, the `package.hugo.json` and `package.json` files were changed in lockstep (see ed9cbda89087db6e47883faf14e0de6e8218c6b6).

The `package.hugo.json` file is picked up when using the repository as a Module, and without this change it would bring in Tailwind 2.x as a dependency (I personally ran into this problem).